### PR TITLE
fixed badGuardian tests

### DIFF
--- a/tests/index.test.js
+++ b/tests/index.test.js
@@ -278,7 +278,7 @@ describe("Tamagotchi Class", () => {
     fizz.energy = 0;
     fizz.mood = 9;
     fizz.full = 9;
-    fizz.status();
+    fizz.badGuardian();
     expect(fizz.rehomed).toBe(true);
   });
 
@@ -286,7 +286,7 @@ describe("Tamagotchi Class", () => {
     fizz.mood = 0;
     fizz.energy = 9;
     fizz.full = 9;
-    fizz.status();
+    fizz.badGuardian();
     expect(fizz.rehomed).toBe(true);
   });
 
@@ -294,7 +294,7 @@ describe("Tamagotchi Class", () => {
     fizz.mood = 9;
     fizz.energy = 9;
     fizz.full = 0;
-    fizz.status();
+    fizz.badGuardian();
     expect(fizz.rehomed).toBe(true);
   });
 });


### PR DESCRIPTION
In the badGuardian tests, fizz.status() should be fizz.badGuardian()